### PR TITLE
Fix sponsors section to prevent overflow on mobile

### DIFF
--- a/components/SponsorSection.module.scss
+++ b/components/SponsorSection.module.scss
@@ -2,6 +2,10 @@
   display: flex;
   justify-content: center;
   margin-bottom: 1em;
+  
+  img {
+    max-width: 100%;
+  }
 }
 
 .sponsorGrid {


### PR DESCRIPTION
I couldn't see the menu on my phone unless I scrolled to the right, and discovered it was because the sponsor section overflowed the page width, so gave it a max-width.

| Before | After |
| ------- | ------ |
| ![image](https://user-images.githubusercontent.com/22779056/134092749-a98bac98-4507-4ce7-af08-cf30f695fe27.png) ![image](https://user-images.githubusercontent.com/22779056/134092778-508c589b-66e9-4214-9aee-f72200a090d7.png) | ![image](https://user-images.githubusercontent.com/22779056/134092953-7ec34c83-cfbe-439f-9eb0-ffe52be2bcac.png) |
 